### PR TITLE
Support list of hash

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,17 @@ puts [['#', 'japanese'], [1, '一']].to_md
 # | # | japanese |
 # | --- | --- |
 # | 1 | 一 |
+
+puts [{id: 1, name: 'John'}, {id: 2, name: 'David'}].to_md
+# | id | name |
+# | --- | --- |
+# | 1 | John |
+# | 2 | David |
+
+puts [[:name, :age], {id: 3, name: 'Robert', age: 20}].to_md
+# | name | age |
+# | --- | --- |
+# | Robert | 20 |
 ```
 
 ## Development

--- a/lib/to_md.rb
+++ b/lib/to_md.rb
@@ -1,19 +1,53 @@
 require "to_md/version"
 
+require "to_md/version"
+
 module ToMd
   refine(Array) do
     def to_md
-      # list
-      unless all? {|e| e.is_a?(Array) }
-        return map {|s| "- #{s}"}.join($/)
+      if first.is_a? Array
+        TableBuilder.build first, drop(1)
+      elsif all?{|e|e.is_a? Hash}
+        TableBuilder.build_with_hash self
+      else
+        #list
+        map {|s| "- #{s}"}.join($/)
+      end
+    end
+  end
+
+  module TableBuilder
+    class << self
+
+      def build_with_hash items
+        keys = items.map(&:keys).inject(:|)
+        build keys, items
       end
 
-      # table
-      [
-        "| #{first.join(' | ')} |",
-        "|#{' --- |' * first.size}",
-        drop(1).map {|s| "| #{s.join(' | ')} |"}.join($/)
-      ].join($/) + $/
+      def build header, items
+        [
+          row(header),
+          row(header.map{'---'}),
+          *items.map{|item|row item_to_array(header, item)}
+        ].join($/)+$/
+      end
+
+      def item_to_array header, item
+        if Hash === item
+          header.map{|key|item[key]}
+        else
+          item = [*item] unless Array === item
+          header.zip(item).map(&:last)
+        end
+      end
+
+      def row array
+        '| '+array.map{|c|escape_cell c}.join(' | ')+' |'
+      end
+
+      def escape_cell text
+        text.to_s.gsub('|', '&#124;').gsub($/, '&#10;')
+      end
     end
   end
 end

--- a/test/to_md_test.rb
+++ b/test/to_md_test.rb
@@ -18,4 +18,33 @@ class ToMdTest < Minitest::Test
 | 1 | 一 |
 TABLE
   end
+
+  def test_array_of_hash_to_md
+    assert_equal([{name: 'a', age: 3}, {name: 'b', age: 4}].to_md, <<TABLE)
+| name | age |
+| --- | --- |
+| a | 3 |
+| b | 4 |
+TABLE
+  end
+
+  def test_mixed_array_with_header_to_md
+    array = [[:id, :name], {name: 'aaa', age: 3}, [2, 'bbb'], nil, 'ccc']
+    assert_equal(array.to_md, <<TABLE)
+| id | name |
+| --- | --- |
+|  | aaa |
+| 2 | bbb |
+|  |  |
+| ccc |  |
+TABLE
+  end
+
+  def test_to_md_table_escape
+    assert_equal([['escape',"a|b\nc"]].to_md, <<TABLE)
+| escape | a&#124;b&#10;c |
+| --- | --- |
+TABLE
+  end
+
 end


### PR DESCRIPTION
escape

``` ruby
[['id', 'name'], [3, 'foo | bar']].to_md
# | id | name |
# | --- | --- |
# | 3 | foo &#124; bar |
```

list of hash to markdown

``` ruby
puts [{id: 1, name: 'John'}, {id: 2, name: 'David'}].to_md
# | id | name |
# | --- | --- |
# | 1 | John |
# | 2 | David |
```
